### PR TITLE
Feature: Weight settings, profile management

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PathfindSanctum {
+    internal static class Constants {
+        internal static class Profiles {
+            public const string Default = "Default";
+            public const string NoHit = "No-Hit";
+        }
+
+        internal static class RoomTypes {
+            public const string Gauntlet = "Gauntlet";
+            public const string Hourglass = "Hourglass";
+            public const string Chalice = "Chalice";
+            public const string Ritual = "Ritual";
+            public const string Escape = "Escape";
+            public const string Boss = "Boss";
+        }
+
+        internal static class AfflictionTypes {
+            public const string GlassShard = "Glass Shard";
+            public const string GhastlyScythe = "Ghastly Scythe";
+            public const string VeiledSight = "Veiled Sight";
+            public const string MyriadAspersions = "Myriad Aspersions";
+            public const string DeceptiveMirror = "Deceptive Mirror";
+            public const string PurpleSmoke = "Purple Smoke";
+            public const string GoldenSmoke = "Golden Smoke";
+            public const string RedSmoke = "Red Smoke";
+            public const string BlackSmoke = "Black Smoke";
+            public const string RapidQuicksand = "Rapid Quicksand";
+            public const string DeadlySnare = "Deadly Snare";
+            public const string ForgottenTraditions = "Forgotten Traditions";
+            public const string SeasonOfFamine = "Season of Famine";
+            public const string OrbOfNegation = "Orb of Negation";
+            public const string WinterDrought = "Winter Drought";
+            public const string BrandedBalbalakh = "Branded Balbalakh";
+            public const string ChiselledStone = "Chiselled Stone";
+            public const string WeakenedFlesh = "Weakened Flesh";
+            public const string Untouchable = "Untouchable";
+            public const string CostlyAid = "Costly Aid";
+            public const string BluntSword = "Blunt Sword";
+            public const string SpikedShell = "Spiked Shell";
+            public const string SuspectedSympathiser = "Suspected Sympathiser";
+            public const string Haemorrhage = "Haemorrhage";
+            public const string CorrosiveConcoction = "Corrosive Concoction";
+            public const string IronManacles = "Iron Manacles";
+            public const string ShatteredShield = "Shattered Shield";
+            public const string UnquenchedThirst = "Unquenched Thirst";
+            public const string UnassumingBrick = "Unassuming Brick";
+            public const string TraditionsDemand = "Tradition's Demand";
+            public const string FiendishWings = "Fiendish Wings";
+            public const string HungryFangs = "Hungry Fangs";
+            public const string WornSandals = "Worn Sandals";
+            public const string TradeTariff = "Trade Tariff";
+            public const string DeathToll = "Death Toll";
+            public const string SpikedExit = "Spiked Exit";
+            public const string ExhaustedWells = "Exhausted Wells";
+            public const string GateToll = "Gate Toll";
+            public const string LeakingWaterskin = "Leaking Waterskin";
+            public const string LowRivers = "Low Rivers";
+            public const string SharpenedArrowhead = "Sharpened Arrowhead";
+            public const string RustedMallet = "Rusted Mallet";
+            public const string ChainsOfBinding = "Chains of Binding";
+            public const string DishonouredTattoo = "Dishonoured Tattoo";
+            public const string TatteredBlindfold = "Tattered Blindfold";
+            public const string DarkPit = "Dark Pit";
+            public const string HonedClaws = "Honed Claws";
+        }
+
+        internal static class RewardTypes {
+            public const string GoldKey = "Gold Key";
+            public const string SilverKey = "Silver Key";
+            public const string BronzeKey = "Bronze Key";
+            public const string GoldenCache = "Golden Cache";
+            public const string SilverCache = "Silver Cache";
+            public const string BronzeCache = "Bronze Cache";
+            public const string LargeFountain = "Large Fountain";
+            public const string Fountain = "Fountain";
+            public const string PledgeToKochai = "Pledge to Kochai";
+            public const string HonourHalani = "Honour Halani";
+            public const string HonourAhkeli = "Honour Ahkeli";
+            public const string HonourOrbala = "Honour Orbala";
+            public const string HonourGalai = "Honour Galai";
+            public const string HonourTabana = "Honour Tabana";
+            public const string Merchant = "Merchant";
+        }
+    }
+
+}

--- a/PathFinder.cs
+++ b/PathFinder.cs
@@ -162,7 +162,7 @@ public class PathFinder(
     #region Visualization
     public void DrawDebugInfo()
     {
-        if (!settings.DebugEnable.Value)
+        if (!settings.DebugSettings.DebugEnable.Value)
             return;
 
         var roomsByLayer = sanctumStateTracker.roomsByLayer;
@@ -183,12 +183,14 @@ public class PathFinder(
                     : string.Empty;
                 var displayText = $"Weight: {roomWeights[layer, room]:F0}\n{debugText}";
 
-                graphics.DrawTextWithBackground(
-                    displayText,
-                    pos,
-                    settings.TextColor,
-                    settings.BackgroundColor
-                );
+                using(graphics.SetTextScale(settings.DebugSettings.DebugFontSizeMultiplier)) {
+                    graphics.DrawTextWithBackground(
+                        displayText,
+                        pos,
+                        settings.StyleSettings.TextColor,
+                        settings.StyleSettings.BackgroundColor
+                    );
+                }
             }
         }
     }
@@ -210,8 +212,8 @@ public class PathFinder(
 
             graphics.DrawFrame(
                 sanctumRoom.GetClientRect(),
-                settings.BestPathColor,
-                settings.FrameThickness
+                settings.StyleSettings.BestPathColor,
+                settings.StyleSettings.FrameThickness
             );
         }
     }

--- a/PathfindSanctum.csproj
+++ b/PathfindSanctum.csproj
@@ -18,6 +18,9 @@
       <HintPath>$(exileCore2Package)\GameOffsets2.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Serilog">
+      <HintPath>$(exileCore2Package)\Serilog.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ImGui.NET" Version="1.90.0.1" />

--- a/PathfindSanctumPlugin.cs
+++ b/PathfindSanctumPlugin.cs
@@ -1,4 +1,5 @@
 using ExileCore2;
+using ImGuiNET;
 
 namespace PathfindSanctum;
 
@@ -7,6 +8,15 @@ public class PathfindSanctumPlugin : BaseSettingsPlugin<PathfindSanctumSettings>
     private readonly SanctumStateTracker stateTracker = new();
     private PathFinder pathFinder;
     private WeightCalculator weightCalculator;
+
+    private string saveAsName = string.Empty;
+
+    // ImGUI Flags
+    private bool showSaveDialog;
+    private bool showDeleteDialog;
+    private bool showResetDialog;
+    private bool showSaveAsNewProfileDialog;
+    private bool showSaveAsInvalidNameError;
 
     public override bool Initialise()
     {
@@ -43,12 +53,224 @@ public class PathfindSanctumPlugin : BaseSettingsPlugin<PathfindSanctumSettings>
         UpdateAndRenderPath();
     }
 
+    public override void DrawSettings() {
+        // Draw profile selection
+        //Settings.ProfileManager.ProfileNames = Settings.Profiles.Keys.ToArray();
+        ImGui.Text("Profile Selection");
+
+        /*
+        //Dropdown list
+        if (ImGui.Combo("string.Empty", ref Settings.selectedProfileIndex, Settings.profileNames, Settings.profileNames.Length)) {
+            Settings.LoadSelectedProfile();
+        }
+        */
+
+        // ListBox - saves a click and doesn't obstruct buttons
+        if (ImGui.ListBox(string.Empty, ref Settings.selectedProfileIndex, Settings.ProfileManager.ProfileNames, Settings.ProfileManager.ProfileNames.Length)) {
+            Settings.ProfileManager.LoadSelectedProfile();
+        }
+
+        // Draw profile selection buttons
+        if (ImGui.Button("Save")) {
+            showSaveDialog = true;
+        }
+        if (ImGui.IsItemHovered()) {
+            ImGui.SetTooltip("Save configured custom weights to the currently selected profile");
+        }
+        ImGui.SameLine();
+        if (ImGui.Button("Save as")) {
+            showSaveAsNewProfileDialog = true;
+        }
+        if (ImGui.IsItemHovered()) {
+            ImGui.SetTooltip("Save configured custom weights as a new profile");
+        }
+        ImGui.SameLine();
+        if (ImGui.Button("Reset")) {
+            showResetDialog = true;
+        }
+        if (ImGui.IsItemHovered()) {
+            ImGui.SetTooltip("Reset currently selected profile to default values");
+        }
+        ImGui.SameLine();
+        if (ImGui.Button("Delete")) {
+            showDeleteDialog = true;
+        }
+        if (ImGui.IsItemHovered()) {
+            ImGui.SetTooltip("Delete the currently selected profile");
+        }
+
+        // Draw dialogs 
+        DrawSaveDialog();
+        DrawSaveAsNewDialog();
+        DrawResetProfileDialog();
+        DrawDeleteProfileDialog();
+
+        // Draw remaining settings from PathfindSanctumSettings class annotations
+        base.DrawSettings();
+    }
+
+    private void DrawSaveDialog() {
+        if (showSaveDialog) {
+            int buttonWidth = 60;
+            var center = ImGui.GetMainViewport().GetCenter();
+            ImGui.SetNextWindowPos(center, ImGuiCond.Appearing, new System.Numerics.Vector2(0.5f, 0.5f));
+            ImGui.SetNextWindowSize(new System.Numerics.Vector2(400, 0));
+            // Check if saving profile is allowed
+            if (Settings.ProfileManager.ProtectedProfiles.Contains(Settings.CurrentProfile)) {
+                ImGui.OpenPopup("Error saving profile");
+                if (ImGui.BeginPopupModal("Error saving profile", ref showSaveDialog, ImGuiWindowFlags.AlwaysAutoResize)) {
+                    ImGui.TextWrapped("You can not override the built-in profiles 'Default' and 'No-Hit'!\n \nSave as new profile instead!\n ");
+                    ImGui.SetCursorPosX((ImGui.GetContentRegionAvail().X - buttonWidth) * 0.5f);
+                    if (ImGui.Button("Ok", new System.Numerics.Vector2(buttonWidth, 0))) {
+                        showSaveDialog = false;
+                        ImGui.CloseCurrentPopup();
+                    }
+                    ImGui.EndPopup();
+                }
+            } else {
+                ImGui.OpenPopup("Confirm save");
+                if (ImGui.BeginPopupModal("Confirm save", ref showSaveDialog, ImGuiWindowFlags.AlwaysAutoResize)) {
+
+                    ImGui.TextWrapped($"Save your currently configured custom weights to profile '{Settings.CurrentProfile}'?\n ");
+                    ImGui.SetCursorPosX((ImGui.GetContentRegionAvail().X - (buttonWidth * 2) + 10) * 0.5f);
+                    if (ImGui.Button("Yes", new System.Numerics.Vector2(buttonWidth, 0))) {
+                        Settings.ProfileManager.SaveProfileAs(Settings.CurrentProfile);
+                        showSaveDialog = false;
+                        ImGui.CloseCurrentPopup();
+                    }
+                    ImGui.SameLine();
+                    if (ImGui.Button("No", new System.Numerics.Vector2(buttonWidth, 0))) {
+                        showSaveDialog = false;
+                        ImGui.CloseCurrentPopup();
+                    }
+                    ImGui.EndPopup();
+                }
+            }
+        }
+    }
+
+    private void DrawSaveAsNewDialog() {
+        if (showSaveAsNewProfileDialog) {
+            int buttonWidth = 100;
+            var center = ImGui.GetMainViewport().GetCenter();
+            ImGui.SetNextWindowPos(center, ImGuiCond.Appearing, new System.Numerics.Vector2(0.5f, 0.5f));
+            ImGui.SetNextWindowSize(new System.Numerics.Vector2(400, 0));
+            ImGui.OpenPopup("Save as new profile");
+            if (ImGui.BeginPopupModal("Save as new profile", ref showSaveAsNewProfileDialog)) {
+                ImGui.TextWrapped("This will save your currently configured custom weights to a new profile.\n ");
+                ImGui.TextWrapped("Please enter a name and confirm to save");
+                ImGui.InputText("##SaveAsProfileName", ref saveAsName, 42);
+                ImGui.Text(" ");
+                buttonWidth = 100;
+                if (ImGui.Button("Save", new System.Numerics.Vector2(buttonWidth, 0))) {
+                    if (Settings.ProfileManager.ProtectedProfiles.Contains(saveAsName) || string.IsNullOrWhiteSpace(saveAsName)) {
+                        showSaveAsInvalidNameError = true;
+                        //Settings.showSaveAsNewProfileDialog = false;
+                        //ImGui.CloseCurrentPopup();
+                    } else {
+                        Settings.ProfileManager.SaveProfileAs(saveAsName);
+                        saveAsName = string.Empty;
+                        showSaveAsNewProfileDialog = false;
+                        ImGui.CloseCurrentPopup();
+                    }
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Cancel", new System.Numerics.Vector2(buttonWidth, 0))) {
+                    showSaveAsNewProfileDialog = false;
+                    ImGui.CloseCurrentPopup();
+                }
+
+                // Draw save as error popup 
+                if (showSaveAsInvalidNameError) {
+                    ImGui.SetNextWindowPos(center, ImGuiCond.Appearing, new System.Numerics.Vector2(0.5f, 0.5f));
+                    ImGui.SetNextWindowSize(new System.Numerics.Vector2(400, 0));
+                    ImGui.OpenPopup("Error saving profile");
+                    if (ImGui.BeginPopupModal("Error saving profile", ref showSaveAsInvalidNameError, ImGuiWindowFlags.AlwaysAutoResize)) {
+                        ImGui.TextWrapped("Invalid name!\nName cannot be empty and you can not override the built-in profiles 'Default' and 'No-Hit'\n ");
+                        ImGui.SetCursorPosX((ImGui.GetContentRegionAvail().X - buttonWidth) * 0.5f);
+                        if (ImGui.Button("Ok", new System.Numerics.Vector2(buttonWidth, 0))) {
+                            showSaveAsInvalidNameError = false;
+                        }
+                        ImGui.EndPopup();
+                    }
+                }
+
+                ImGui.EndPopup();
+            }
+        }
+    }
+
+    private void DrawResetProfileDialog() {
+        if (showResetDialog) {
+            int buttonWidth = 60;
+            var center = ImGui.GetMainViewport().GetCenter();
+            ImGui.SetNextWindowPos(center, ImGuiCond.Appearing, new System.Numerics.Vector2(0.5f, 0.5f));
+            ImGui.SetNextWindowSize(new System.Numerics.Vector2(400, 0));
+            ImGui.OpenPopup("Confirm reset");
+            if (ImGui.BeginPopupModal("Confirm reset", ref showResetDialog, ImGuiWindowFlags.AlwaysAutoResize)) {
+
+                ImGui.TextWrapped($"Are you sure you want to reset the profile '{Settings.CurrentProfile}' to default values?\n ");
+                ImGui.SetCursorPosX((ImGui.GetContentRegionAvail().X - ((buttonWidth * 2) + 10)) * 0.5f);
+                if (ImGui.Button("Yes", new System.Numerics.Vector2(buttonWidth, 0))) {
+                    Settings.ProfileManager.ResetCurrentProfileToDefault();
+                    showResetDialog = false;
+                    ImGui.CloseCurrentPopup();
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("No", new System.Numerics.Vector2(buttonWidth, 0))) {
+                    showResetDialog = false;
+                    ImGui.CloseCurrentPopup();
+                }
+                ImGui.EndPopup();
+            }
+        }
+    }
+
+    private void DrawDeleteProfileDialog() {
+        if (showDeleteDialog) {
+            int buttonWidth = 60;
+            var center = ImGui.GetMainViewport().GetCenter();
+            ImGui.SetNextWindowPos(center, ImGuiCond.Appearing, new System.Numerics.Vector2(0.5f, 0.5f));
+            ImGui.SetNextWindowSize(new System.Numerics.Vector2(400, 0));
+            // Check if deleting profile is allowed
+            if (Settings.ProfileManager.ProtectedProfiles.Contains(Settings.CurrentProfile)) {
+                ImGui.OpenPopup("Error deleting profile");
+                if (ImGui.BeginPopupModal("Error deleting profile", ref showDeleteDialog, ImGuiWindowFlags.AlwaysAutoResize)) {
+                    ImGui.TextWrapped("You can not delete the built-in profiles 'Default' and 'No-Hit'!\n ");
+                    ImGui.SetCursorPosX((ImGui.GetContentRegionAvail().X - buttonWidth) * 0.5f);
+                    if (ImGui.Button("Ok", new System.Numerics.Vector2(buttonWidth, 0))) {
+                        showDeleteDialog = false;
+                        ImGui.CloseCurrentPopup();
+                    }
+                    ImGui.EndPopup();
+                }
+            } else {
+                ImGui.OpenPopup("Confirm deletion");
+                if (ImGui.BeginPopupModal("Confirm deletion", ref showDeleteDialog, ImGuiWindowFlags.AlwaysAutoResize)) {
+                    ImGui.TextWrapped($"Are you sure you want to delete the profile '{Settings.CurrentProfile}'?\n ");
+                    ImGui.SetCursorPosX((ImGui.GetContentRegionAvail().X - (buttonWidth * 2) + 10) * 0.5f);
+                    if (ImGui.Button("Yes", new System.Numerics.Vector2(buttonWidth, 0))) {
+                        Settings.ProfileManager.DeleteCurrentProfile();
+                        showDeleteDialog = false;
+                        ImGui.CloseCurrentPopup();
+                    }
+                    ImGui.SameLine();
+                    if (ImGui.Button("No", new System.Numerics.Vector2(buttonWidth, 0))) {
+                        showDeleteDialog = false;
+                        ImGui.CloseCurrentPopup();
+                    }
+                    ImGui.EndPopup();
+                }
+            }
+        }
+    }
+
     private void UpdateAndRenderPath()
     {
         // TODO: Optimize this so it's not executed on every render (maybe only executed if we updated our known states)
         pathFinder.CreateRoomWeightMap();
 
-        if (Settings.DebugEnable)
+        if (Settings.DebugSettings.DebugEnable)
         {
             pathFinder.DrawDebugInfo();
         }

--- a/PathfindSanctumSettings.cs
+++ b/PathfindSanctumSettings.cs
@@ -9,6 +9,18 @@ public class PathfindSanctumSettings : ISettings
 {
     public ToggleNode Enable { get; set; } = new ToggleNode(true);
     public ToggleNode DebugEnable { get; set; } = new ToggleNode(false);
+    [Menu("Custom Weight Settings")]
+    public CustomWeightSettings CustomWeights { get; set; } = new CustomWeightSettings();
+
+    [Menu("Advanced Settings")]
+    public AdvancedSettings AdvancedSettings { get; set; } = new AdvancedSettings();
+
+    [Menu("Style Settings")]
+    public StyleSettings StyleSettings { get; set; } = new StyleSettings();
+
+    [Menu("Debug Settings")]
+    public DebugSettings DebugSettings { get; set; } = new DebugSettings();
+
 
     public Dictionary<string, ProfileContent> Profiles =
         new()

--- a/PathfindSanctumSettings.cs
+++ b/PathfindSanctumSettings.cs
@@ -20,9 +20,9 @@ public class PathfindSanctumSettings : ISettings {
     public int selectedProfileIndex = 0;
     internal string CurrentProfile { get { return ProfileManager.ProfileNames[selectedProfileIndex]; } }
 
-
-    [Menu("Custom Weight Settings")]
-    public CustomWeightSettings CustomWeights { get; set; } = new CustomWeightSettings();
+    [JsonIgnore]
+    [Menu("Weight Settings")]
+    public CustomWeightSettings Weights { get; set; } = new CustomWeightSettings();
 
     [Menu("Advanced Settings")]
     public AdvancedSettings AdvancedSettings { get; set; } = new AdvancedSettings();
@@ -48,23 +48,6 @@ public class PathfindSanctumSettings : ISettings {
     private async void LoadSavedSettingsAfterStart() {
         await Task.Delay(1000);
         ProfileManager.LoadSelectedProfile();
-    }
-
-    internal bool GetWeightValue( string key, out float value) {
-        if (CustomWeights.RoomTypeWeights.GetWeight(key, out int roomValue)) {
-            value = roomValue;
-            return true;
-        }
-        if (CustomWeights.AfflictionWeights.GetWeight(key, out int afflictionValue)) {
-            value = afflictionValue;
-            return true;
-        }
-        if (CustomWeights.RewardWeights.GetWeight(key, out int rewardValue)) {
-            value = rewardValue;
-            return true;
-        }
-        value = 0;
-        return false;
     }
 }
 

--- a/PathfindSanctumSettings.cs
+++ b/PathfindSanctumSettings.cs
@@ -28,6 +28,24 @@ public class PathfindSanctumSettings : ISettings
             ["Default"] = ProfileContent.CreateDefaultProfile(),
             ["No-Hit"] = ProfileContent.CreateNoHitProfile()
         };
+    internal bool GetWeightValue( string key, out float value) {
+        if (CustomWeights.RoomTypeWeights.GetWeight(key, out int roomValue)) {
+            value = roomValue;
+            return true;
+        }
+        if (CustomWeights.AfflictionWeights.GetWeight(key, out int afflictionValue)) {
+            value = afflictionValue;
+            return true;
+        }
+        if (CustomWeights.RewardWeights.GetWeight(key, out int rewardValue)) {
+            value = rewardValue;
+            return true;
+        }
+        value = 0;
+        return false;
+    }
+}
+
 [Submenu(CollapsedByDefault = true)]
 public class CustomWeightSettings {
     [Menu("Room Type Weights")]

--- a/PathfindSanctumSettings.cs
+++ b/PathfindSanctumSettings.cs
@@ -294,21 +294,13 @@ public class StyleSettings {
     public ColorNode BackgroundColor { get; set; } = new ColorNode(Color.FromArgb(128, 0, 0, 0));
     public ColorNode BestPathColor { get; set; } = new(Color.Cyan);
     public RangeNode<int> FrameThickness { get; set; } = new RangeNode<int>(5, 0, 10);
+}
 
-    public PathfindSanctumSettings()
-    {
-        CurrentProfile = new ListNode { Values = [.. Profiles.Keys], Value = "Default" };
-        ResetProfile.OnPressed += () => ResetCurrentProfileToDefault();
-    }
+[Submenu(CollapsedByDefault = true)]
+public class DebugSettings {
+    [Menu("Enable Debug Text", "Draw debug information on the floor map")]
+    public ToggleNode DebugEnable { get; set; } = new ToggleNode(false);
 
-    private void ResetCurrentProfileToDefault()
-    {
-        var currentProfileName = CurrentProfile.Value;
-        Profiles[currentProfileName] = currentProfileName switch
-        {
-            "Default" => ProfileContent.CreateDefaultProfile(),
-            "No-Hit" => ProfileContent.CreateNoHitProfile(),
-            _ => ProfileContent.CreateDefaultProfile()
-        };
-    }
+    [Menu("Debug Font Size")]
+    public RangeNode<float> DebugFontSizeMultiplier { get; set; } = new RangeNode<float>(1.0f, 0.5f, 2f);
 }

--- a/PathfindSanctumSettings.cs
+++ b/PathfindSanctumSettings.cs
@@ -28,9 +28,268 @@ public class PathfindSanctumSettings : ISettings
             ["Default"] = ProfileContent.CreateDefaultProfile(),
             ["No-Hit"] = ProfileContent.CreateNoHitProfile()
         };
+[Submenu(CollapsedByDefault = true)]
+public class CustomWeightSettings {
+    [Menu("Room Type Weights")]
+    public RoomTypeWeightSettings RoomTypeWeights { get; set; } = new RoomTypeWeightSettings();
+        
+    [Menu("Affliction Weights")]
+    public AfflictionWeightSettings AfflictionWeights{ get; set; } = new AfflictionWeightSettings();
 
-    public ListNode CurrentProfile { get; set; }
-    public ButtonNode ResetProfile { get; set; } = new ButtonNode();
+    [Menu("Reward Weights")]
+    public RewardWeightSettings RewardWeights{ get; set; } = new RewardWeightSettings();
+
+}
+
+[Submenu(CollapsedByDefault = true)]
+public class RoomTypeWeightSettings : WeightSettings {
+    [Menu(Constants.RoomTypes.Gauntlet, "Levers, Traps, large layout. Generally annoying.")]
+    public RangeNode<int> GauntletWeight { get; set; } = new RangeNode<int>(-1000, -1000, 1000);
+
+    [Menu(Constants.RoomTypes.Hourglass, "Dense mobs but manageable with strong character")]
+    public RangeNode<int> HourglassWeight { get; set; } = new RangeNode<int>(-200, -1000, 1000);
+
+    [Menu(Constants.RoomTypes.Chalice, "Kill all rare mobs. Quick and easy.")]
+    public RangeNode<int> ChaliceWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RoomTypes.Ritual, "Clear all ritual sites. Quick and easy.")]
+    public RangeNode<int> RitualWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RoomTypes.Escape, "Crystals. Safe, controlled environment. Just run through. Quick and easy.")]
+    public RangeNode<int> EscapeWeight { get; set; } = new RangeNode<int>(100, -1000, 1000);
+
+    [Menu(Constants.RoomTypes.Boss)]
+    public RangeNode<int> BossWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+}
+
+[Submenu(CollapsedByDefault = true)]
+public class AfflictionWeightSettings : WeightSettings {
+    [Menu(Constants.AfflictionTypes.GlassShard, "The next Boon you gain is converted into a random Minor Affliction")]
+    public RangeNode<int> GlassShardWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.GhastlyScythe, "Losing Honour ends the Trial (removed after 3 rooms)")]
+    public RangeNode<int> GhastlyScytheWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.VeiledSight, "Rooms are unknown on the Trial Map")]
+    public RangeNode<int> VeiledSightWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.MyriadAspersions, "When you gain an Affliction, gain an additional random Minor Affliction")]
+    public RangeNode<int> MyriadAspersionsWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.DeceptiveMirror, "You are not always taken to the room you select")]
+    public RangeNode<int> DeceptiveMirrorWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.PurpleSmoke, "Afflictions are unknown on the Trial Map")]
+    public RangeNode<int> PurpleSmokeWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.GoldenSmoke, "Rewards are unknown on the Trial Map")]
+    public RangeNode<int> GoldenSmokeWeight { get; set; } = new RangeNode<int>(-400, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.RedSmoke, "Room types are unknown on the Trial Map")]
+    public RangeNode<int> RedSmokeWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.BlackSmoke, "You can see one fewer room ahead on the Trial Map")]
+    public RangeNode<int> BlackSmokeWeight { get; set; } = new RangeNode<int>(-4000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.RapidQuicksand, "Traps are faster")]
+    public RangeNode<int> RapidQuicksandWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.DeadlySnare, "Traps deal Triple Damage")]
+    public RangeNode<int> DeadlySnareWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.ForgottenTraditions, "50%% reduced Effect of your Non-Unique Relics")]
+    public RangeNode<int> ForgottenTraditionsWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.SeasonOfFamine, "The Merchant offers 50%% fewer choices")]
+    public RangeNode<int> SeasonOfFamineWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.OrbOfNegation, "Non-Unique Relics have no Effect")]
+    public RangeNode<int> OrbOfNegationWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.WinterDrought, "Lose all Sacred Water on floor completion")]
+    public RangeNode<int> WinterDroughtWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.BrandedBalbalakh, "Cannot restore Honour")]
+    public RangeNode<int> BrandedBalbalakhWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.ChiselledStone, "Monsters Petrify on Hit")]
+    public RangeNode<int> ChiselledStoneWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.WeakenedFlesh, "25%% less Maximum Honour")]
+    public RangeNode<int> WeakenedFleshWeight { get; set; } = new RangeNode<int>(-100, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.Untouchable, "You are cursed with Enfeeble")]
+    public RangeNode<int> UntouchableWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.CostlyAid, "Gain a random Minor Affliction when you venerate a Maraketh Shrine")]
+    public RangeNode<int> CostlyAidWeight { get; set; } = new RangeNode<int>(-900, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.BluntSword, "You and your Minions deal 40%% less Damage")]
+    public RangeNode<int> BluntSwordWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.SpikedShell, "Monsters have 50%% increased Maximum Life")]
+    public RangeNode<int> SpikedShellWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.SuspectedSympathiser, "50%% reduced Honour restored")]
+    public RangeNode<int> SuspectedSympathiserWeight { get; set; } = new RangeNode<int>(-200, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.Haemorrhage, "You cannot restore Honour (removed after killing the next Boss)")]
+    public RangeNode<int> HaemorrhageWeight { get; set; } = new RangeNode<int>(-100, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.CorrosiveConcoction, "You have no Defences (Only matters if you're EV or ES based)")]
+    public RangeNode<int> CorrosiveConcoctionWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.IronManacles, "You have no Evasion")]
+    public RangeNode<int> IronManaclesWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.ShatteredShield, "You have no Energy Shield")]
+    public RangeNode<int> ShatteredShieldWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.UnquenchedThirst, "You cannot gain Sacred Water (Floor 4 this is nearly-free, depends on how many merchants you got left)")]
+    public RangeNode<int> UnquenchedThirstWeight { get; set; } = new RangeNode<int>(-200, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.UnassumingBrick, "You cannot gain any more Boons (Floor 4 this is nearly-free, depends on how many merchants you got left)")]
+    public RangeNode<int> UnassumingBrickWeight { get; set; } = new RangeNode<int>(-1000, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.TraditionsDemand, "The Merchant only offers one choice")]
+    public RangeNode<int> TraditionsDemandWeight { get; set; } = new RangeNode<int>(-800, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.FiendishWings, "Monsters' Action Speed cannot be slowed below base (Matters more if you're freezing/electrocuting the target)")]
+    public RangeNode<int> FiendishWingsWeight { get; set; } = new RangeNode<int>(-400, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.HungryFangs, "Monsters remove 5%% of your Life, Mana and Energy Shield on Hit")]
+    public RangeNode<int> HungryFangsWeight { get; set; } = new RangeNode<int>(-600, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.WornSandals, "25%% reduced Movement Speed")]
+    public RangeNode<int> WornSandalsWeight { get; set; } = new RangeNode<int>(-400, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.TradeTariff, "50%% increased Merchant prices")]
+    public RangeNode<int> TradeTariffWeight { get; set; } = new RangeNode<int>(-300, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.DeathToll, "Take flat amount of Physical Damage after completing eight rooms")]
+    public RangeNode<int> DeathTollWeight { get; set; } = new RangeNode<int>(-400, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.SpikedExit, "Take flat amount of Physical Damage on Room Completion")]
+    public RangeNode<int> SpikedExitWeight { get; set; } = new RangeNode<int>(-300, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.ExhaustedWells, "Chests no longer grant Sacred Water")]
+    public RangeNode<int> ExhaustedWellsWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.GateToll, "Lose 30 Sacred Water on room completion")]
+    public RangeNode<int> GateTollWeight { get; set; } = new RangeNode<int>(-100, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.LeakingWaterskin, "Lose 20 Sacred Water when you take Damage from an Enemy Hit")]
+    public RangeNode<int> LeakingWaterskinWeight { get; set; } = new RangeNode<int>(-100, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.LowRivers, "50%% less Sacred Water found")]
+    public RangeNode<int> LowRiversWeight { get; set; } = new RangeNode<int>(-100, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.SharpenedArrowhead, "You have no Armour")]
+    public RangeNode<int> SharpenedArrowheadWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.RustedMallet, "Monsters always Knockback")]
+    public RangeNode<int> RustedMalletWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.ChainsOfBinding, "Monsters inflict Binding Chains on Hit")]
+    public RangeNode<int> ChainsOfBindingWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.DishonouredTattoo, "100%% increased Damage Taken while on Low Life")]
+    public RangeNode<int> DishonouredTattooWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.TatteredBlindfold, "90%% reduced Light Radius")]
+    public RangeNode<int> TatteredBlindfoldWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.DarkPit, "Traps deal 100%% increased Damage")]
+    public RangeNode<int> DarkPitWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+
+    [Menu(Constants.AfflictionTypes.HonedClaws, "Monsters deal 30%% more Damage")]
+    public RangeNode<int> HonedClawsWeight { get; set; } = new RangeNode<int>(0, -5000, 0);
+}
+
+[Submenu(CollapsedByDefault = true)]
+public class RewardWeightSettings : WeightSettings {
+    [Menu(Constants.RewardTypes.GoldKey)]
+    public RangeNode<int> GoldKeyWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.SilverKey)]
+    public RangeNode<int> SilverKeyWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.BronzeKey)]
+    public RangeNode<int> BronzeKeyWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.GoldenCache)]
+    public RangeNode<int> GoldenCacheWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.SilverCache)]
+    public RangeNode<int> SilverCacheWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.BronzeCache)]
+    public RangeNode<int> BronzeCacheWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.LargeFountain, "Large fountain containing Sacred Water")]
+    public RangeNode<int> LargeFountainWeight { get; set; } = new RangeNode<int>(100, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.Fountain, "Regular fountain containing Sacred Water")]
+    public RangeNode<int> FountainWeight { get; set; } = new RangeNode<int>(50, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.PledgeToKochai, "Select one of three random Pledges")]
+    public RangeNode<int> PledgeToKochaiWeight { get; set; } = new RangeNode<int>(20, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.HonourHalani, "Restore Honour and gain Sacred Water")]
+    public RangeNode<int> HonourHalaniWeight { get; set; } = new RangeNode<int>(8, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.HonourAhkeli, "Restore 25%% of your Honour and gain a random Minor Affliction")]
+    public RangeNode<int> HonourAhkeliWeight { get; set; } = new RangeNode<int>(-1, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.HonourOrbala, "Restore 10%% of your Honour and gain a random Boon")]
+    public RangeNode<int> HonourOrbalaWeight { get; set; } = new RangeNode<int>(50, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.HonourGalai, "Restore 50%% of your Honour, Gain a random Boon and cleanse a random Affliction")]
+    public RangeNode<int> HonourGalaiWeight { get; set; } = new RangeNode<int>(300, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.HonourTabana, "Restore 10%% of your Honour")]
+    public RangeNode<int> HonourTabanaWeight { get; set; } = new RangeNode<int>(0, -1000, 1000);
+
+    [Menu(Constants.RewardTypes.Merchant, "Not important if sacred water is below ~360 (less with relics)")]
+    public RangeNode<int> MerchantWeight { get; set; } = new RangeNode<int>(20, -1000, 1000);
+}
+
+[Submenu(CollapsedByDefault = true)]
+public class AdvancedSettings {
+    [Menu("Dynamic Evasion Rating Weights", "Dynamically adjust weights of [Iron Manacles] and [Corrosive Concoction] afflictions based on your character's evasion rating\nThis will ignore the weight set in the profile")]
+    public ToggleNode DynamicEVWeight { get; set; } = new ToggleNode(true);
+
+    [Menu("Evasion Lower Threshold")]
+    public RangeNode<int> DynamicEVLowerThreshold { get; set; } = new RangeNode<int>(6000, 0, 50000);
+
+    [Menu("Evasion Lower Weight", "This weight will be used when your evasion rating is above the lower threshold")]
+    public RangeNode<int> DynamicEVLowerWeight { get; set; } = new RangeNode<int>(-750, -10000, 0);
+
+    [Menu("Evasion Upper Threshold")]
+    public RangeNode<int> DynamicEVUpperThreshold { get; set; } = new RangeNode<int>(20000, 0, 50000);
+
+    [Menu("Evasion Upper Weight", "This weight will be used when your when your evasion rating is above the upper threshold")]
+    public RangeNode<int> DynamicEVUpperWeight { get; set; } = new RangeNode<int>(-5000, -10000, 0);
+
+
+    [Menu("Dynamic Energy Shield Weights", "Dynamically adjust weights of [Shattered Shield] and [Corrosive Concoction] afflictions based on your character's energy shield\nThis will ignore the weight set in the profile")]
+    public ToggleNode DynamicESWeight { get; set; } = new ToggleNode(true);
+
+    [Menu("ES Lower Threshold")]
+    public RangeNode<int> DynamicESLowerThreshold { get; set; } = new RangeNode<int>(1000, 0, 20000);
+
+    [Menu("ES Lower Weight", "This weight will be used when your maximum energy shield surpasses the lower threshold")]
+    public RangeNode<int> DynamicESLowerWeight { get; set; } = new RangeNode<int>(-750, -10000, 0);
+
+    [Menu("ES Upper Threshold")]
+    public RangeNode<int> DynamicESUpperThreshold { get; set; } = new RangeNode<int>(6000, 0, 20000);
+
+    [Menu("ES Lower Weight", "This weight will be used when your maximum energy shield surpasses the upper threshold")]
+    public RangeNode<int> DynamicESUpperWeight { get; set; } = new RangeNode<int>(-5000, -10000, 0);
+}
+
+[Submenu(CollapsedByDefault = true)]
+public class StyleSettings {
     public ColorNode TextColor { get; set; } = new ColorNode(Color.White);
     public ColorNode BackgroundColor { get; set; } = new ColorNode(Color.FromArgb(128, 0, 0, 0));
     public ColorNode BestPathColor { get; set; } = new(Color.Cyan);

--- a/ProfileContent.cs
+++ b/ProfileContent.cs
@@ -169,7 +169,7 @@ public class ProfileContent
 
         MapWeightsToProfile(
             profile.RoomTypeWeights, 
-            settings.CustomWeights.RoomTypeWeights,
+            settings.Weights.RoomTypeWeights,
             (weights, key) => {
                 bool result = weights.GetWeight(key, out int value);
                 return (result, value);
@@ -179,7 +179,7 @@ public class ProfileContent
         
         MapWeightsToProfile(
             profile.AfflictionWeights,
-            settings.CustomWeights.AfflictionWeights,
+            settings.Weights.AfflictionWeights,
             (weights, key) => {
                 bool result = weights.GetWeight(key, out int value);
                 return (result, value);
@@ -189,7 +189,7 @@ public class ProfileContent
 
         MapWeightsToProfile(
             profile.RewardWeights,
-            settings.CustomWeights.RewardWeights,
+            settings.Weights.RewardWeights,
             (weights, key) => {
                 bool result = weights.GetWeight(key, out int value);
                 return (result, value);
@@ -201,9 +201,9 @@ public class ProfileContent
     }
 
     public void LoadProfile(PathfindSanctumSettings settings) {
-        MapWeightsToSettings(settings.CustomWeights.RoomTypeWeights, RoomTypeWeights, (weights, key, value) => weights.SetWeight(key, value));
-        MapWeightsToSettings(settings.CustomWeights.AfflictionWeights, AfflictionWeights, (weights, key, value) => weights.SetWeight(key, value));
-        MapWeightsToSettings(settings.CustomWeights.RewardWeights, RewardWeights, (weights, key, value) => weights.SetWeight(key, value));
+        MapWeightsToSettings(settings.Weights.RoomTypeWeights, RoomTypeWeights, (weights, key, value) => weights.SetWeight(key, value));
+        MapWeightsToSettings(settings.Weights.AfflictionWeights, AfflictionWeights, (weights, key, value) => weights.SetWeight(key, value));
+        MapWeightsToSettings(settings.Weights.RewardWeights, RewardWeights, (weights, key, value) => weights.SetWeight(key, value));
     }
 
     public ProfileContent Clone()

--- a/ProfileContent.cs
+++ b/ProfileContent.cs
@@ -102,6 +102,21 @@ public class ProfileContent
         };
     }
 
+    private static void MapWeightsToProfile<T>(Dictionary<string, float> targetWeights, T sourceWeights, Func<T, string, (bool success, int weight)> getWeight, Action<string, float> setWeight) {
+        foreach (var key in targetWeights.Keys) {
+            var result = getWeight(sourceWeights, key);
+            if (result.success) {
+                setWeight(key, result.weight);
+            }
+        }
+    }
+
+    private static void MapWeightsToSettings<T>(T targetWeights, Dictionary<string, float> sourceWeights, Action<T, string, float> setWeight) {
+        foreach (var key in sourceWeights.Keys.ToList()) {
+            setWeight(targetWeights, key, sourceWeights[key]);
+        }
+    }
+
     public static ProfileContent CreateDefaultProfile()
     {
         var profile = CreateBaseProfile();

--- a/ProfileContent.cs
+++ b/ProfileContent.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PathfindSanctum;
 
@@ -14,90 +16,89 @@ public class ProfileContent
         {
             RoomTypeWeights = new()
             {
-                ["Gauntlet"] = -1000, // Annoying
-                ["Hourglass"] = -200, // Dense mobs but manageable with defenses
-                ["Chalice"] = 0, // Neutral
-                ["Ritual"] = 0, // Neutral
-                ["Escape"] = 100, // Safe, controlled environment
-                ["Boss"] = 0, // Required
+                [Constants.RoomTypes.Gauntlet] = -1000, // Annoying
+                [Constants.RoomTypes.Hourglass] = -200, // Dense mobs but manageable with defenses
+                [Constants.RoomTypes.Chalice] = 0, // Neutral
+                [Constants.RoomTypes.Ritual] = 0, // Neutral
+                [Constants.RoomTypes.Escape] = 100, // Safe, controlled environment
+                [Constants.RoomTypes.Boss] = 0, // Required
             },
             AfflictionWeights = new()
             {
-                ["Orbala's Leathers"] = 0, // Unknown
                 // Can get trapped
-                ["Glass Shard"] = -4000, // The next [Boons|Boon] you gain is converted into a random Minor [Afflictions|Affliction] ||| (Average weight of all afflictions you don't have)
-                ["Ghastly Scythe"] = -4000, // Losing [Honour] ends the Trial (removed after 3 rooms)
-                ["Veiled Sight"] = -4000, // Rooms are unknown on the Trial Map
-                ["Myriad Aspersions"] = -4000, // When you gain an [Afflictions|Affliction], gain an additional random Minor [Afflictions|Affliction]
-                ["Deceptive Mirror"] = -4000, // You are not always taken to the room you select
-                ["Purple Smoke"] = -4000, // [Afflictions] are unknown on the Trial Map
-                ["Golden Smoke"] = -400, // Rewards are unknown on the Trial Map
-                ["Red Smoke"] = -4000, // Room types are unknown on the Trial Map
-                ["Black Smoke"] = -4000, // You can see one fewer room ahead on the Trial Map
+                [Constants.AfflictionTypes.GlassShard] = -4000, // The next [Boons|Boon] you gain is converted into a random Minor [Afflictions|Affliction] ||| (Average weight of all afflictions you don't have)
+                [Constants.AfflictionTypes.GhastlyScythe] = -4000, // Losing [Honour] ends the Trial (removed after 3 rooms)
+                [Constants.AfflictionTypes.VeiledSight] = -4000, // Rooms are unknown on the Trial Map
+                [Constants.AfflictionTypes.MyriadAspersions] = -4000, // When you gain an [Afflictions|Affliction], gain an additional random Minor [Afflictions|Affliction]
+                [Constants.AfflictionTypes.DeceptiveMirror] = -4000, // You are not always taken to the room you select
+                [Constants.AfflictionTypes.PurpleSmoke] = -4000, // [Afflictions] are unknown on the Trial Map
+                [Constants.AfflictionTypes.GoldenSmoke] = -400, // Rewards are unknown on the Trial Map
+                [Constants.AfflictionTypes.RedSmoke] = -4000, // Room types are unknown on the Trial Map
+                [Constants.AfflictionTypes.BlackSmoke] = -4000, // You can see one fewer room ahead on the Trial Map
                 // Quickly makes you lose honour
-                ["Rapid Quicksand"] = -1000, // Traps are faster
-                ["Deadly Snare"] = -1000, // Traps deal Triple Damage
+                [Constants.AfflictionTypes.RapidQuicksand] = -1000, // Traps are faster
+                [Constants.AfflictionTypes.DeadlySnare] = -1000, // Traps deal Triple Damage
                 // Less profit (worse for no-hit runs)
-                ["Forgotten Traditions"] = -1000, // 50% reduced Effect of your Non-[ItemRarity|Unique] [Relic|Relics]
-                ["Season of Famine"] = -1000, // The Merchant offers 50% fewer choices
-                ["Orb of Negation"] = -1000, // Non-[ItemRarity|Unique] [Relic|Relics] have no Effect
-                ["Winter Drought"] = -1000, // Lose all [SacredWater|Sacred Water] on floor completion
+                [Constants.AfflictionTypes.ForgottenTraditions] = -1000, // 50% reduced Effect of your Non-[ItemRarity|Unique] [Relic|Relics]
+                [Constants.AfflictionTypes.SeasonOfFamine] = -1000, // The Merchant offers 50% fewer choices
+                [Constants.AfflictionTypes.OrbOfNegation] = -1000, // Non-[ItemRarity|Unique] [Relic|Relics] have no Effect
+                [Constants.AfflictionTypes.WinterDrought] = -1000, // Lose all [SacredWater|Sacred Water] on floor completion
                 // Problematic if build is weak
-                ["Branded Balbalakh"] = -1000, // Cannot restore [Honour]
-                ["Chiselled Stone"] = -1000, // Monsters [Petrify] on Hit
-                ["Weakened Flesh"] = -100, // 25% less Maximum [Honour]
-                ["Untouchable"] = -1000, // You are [Curse|Cursed] with [Enfeeble]
-                ["Costly Aid"] = -900, // Gain a random Minor [Afflictions|Affliction] when you venerate a Maraketh Shrine
-                ["Blunt Sword"] = -1000, // You and your Minions deal 40% less Damage
-                ["Spiked Shell"] = -1000, // Monsters have 50% increased Maximum Life
-                ["Suspected Sympathiser"] = -200, // 50% reduced [Honour] restored
-                ["Haemorrhage"] = -100, // You cannot restore [Honour] (removed after killing the next Boss)
+                [Constants.AfflictionTypes.BrandedBalbalakh] = -1000, // Cannot restore [Honour]
+                [Constants.AfflictionTypes.ChiselledStone] = -1000, // Monsters [Petrify] on Hit
+                [Constants.AfflictionTypes.WeakenedFlesh] = -100, // 25% less Maximum [Honour]
+                [Constants.AfflictionTypes.Untouchable] = -1000, // You are [Curse|Cursed] with [Enfeeble]
+                [Constants.AfflictionTypes.CostlyAid] = -900, // Gain a random Minor [Afflictions|Affliction] when you venerate a Maraketh Shrine
+                [Constants.AfflictionTypes.BluntSword] = -1000, // You and your Minions deal 40% less Damage
+                [Constants.AfflictionTypes.SpikedShell] = -1000, // Monsters have 50% increased Maximum Life
+                [Constants.AfflictionTypes.SuspectedSympathiser] = -200, // 50% reduced [Honour] restored
+                [Constants.AfflictionTypes.Haemorrhage] = -100, // You cannot restore [Honour] (removed after killing the next Boss)
                 // Problematic for certain builds (handled Dynamically)
-                ["Corrosive Concoction"] = 0, // You have no [Defences] ||| Only matters if you're EV or ES based
-                ["Iron Manacles"] = 0, // You have no [Evasion] ||| Only matters if you're EV based
-                ["Shattered Shield"] = 0, // You have no [EnergyShield|Energy Shield] ||| Only matters if you're ES based
+                [Constants.AfflictionTypes.CorrosiveConcoction] = 0, // You have no [Defences] ||| Only matters if you're EV or ES based
+                [Constants.AfflictionTypes.IronManacles] = 0, // You have no [Evasion] ||| Only matters if you're EV based
+                [Constants.AfflictionTypes.ShatteredShield] = 0, // You have no [EnergyShield|Energy Shield] ||| Only matters if you're ES based
                 // Sucks
-                ["Unquenched Thirst"] = -200, // You cannot gain [SacredWater|Sacred Water] ||| Floor 4 this is nearly-free, depends on how many merchants you got left
-                ["Unassuming Brick"] = -1000, // You cannot gain any more [Boons] ||| Floor 4 this is nearly-free, depends on how many merchants you got left
-                ["Tradition's Demand"] = -800, // The Merchant only offers one choice
-                ["Fiendish Wings"] = -400, // Monsters' Action Speed cannot be slowed below base ||| Matters more if you're freezing/electrocuting the target
-                ["Hungry Fangs"] = -600, // Monsters remove 5% of your Life, Mana and [EnergyShield|Energy Shield] on [HitDamage|Hit]
-                ["Worn Sandals"] = -400, // 25% reduced Movement Speed
-                ["Trade Tariff"] = -300, // 50% increased Merchant prices
+                [Constants.AfflictionTypes.UnquenchedThirst] = -200, // You cannot gain [SacredWater|Sacred Water] ||| Floor 4 this is nearly-free, depends on how many merchants you got left
+                [Constants.AfflictionTypes.UnassumingBrick] = -1000, // You cannot gain any more [Boons] ||| Floor 4 this is nearly-free, depends on how many merchants you got left
+                [Constants.AfflictionTypes.TraditionsDemand] = -800, // The Merchant only offers one choice
+                [Constants.AfflictionTypes.FiendishWings] = -400, // Monsters' Action Speed cannot be slowed below base ||| Matters more if you're freezing/electrocuting the target
+                [Constants.AfflictionTypes.HungryFangs] = -600, // Monsters remove 5% of your Life, Mana and [EnergyShield|Energy Shield] on [HitDamage|Hit]
+                [Constants.AfflictionTypes.WornSandals] = -400, // 25% reduced Movement Speed
+                [Constants.AfflictionTypes.TradeTariff] = -300, // 50% increased Merchant prices
                 // Nearly Free
-                ["Death Toll"] = -400, // Take {0} [Physical] Damage after completing the next Room || ? Monsters no longer drop [SacredWater|Sacred Water]
-                ["Spiked Exit"] = -300, // Take {0} [Physical] Damage on Room Completion
-                ["Exhausted Wells"] = 0, // Chests no longer grant [SacredWater|Sacred Water]
-                ["Gate Toll"] = -100, // Lose 30 [SacredWater|Sacred Water] on room completion
-                ["Leaking Waterskin"] = -100, // Lose 20 [SacredWater|Sacred Water] when you take Damage from an Enemy [HitDamage|Hit]
-                ["Low Rivers"] = -100, // 50% less [SacredWater|Sacred Water] found
+                [Constants.AfflictionTypes.DeathToll] = -400, // Take {0} [Physical] Damage after completing the next Room || ? Monsters no longer drop [SacredWater|Sacred Water]
+                [Constants.AfflictionTypes.SpikedExit] = -300, // Take {0} [Physical] Damage on Room Completion
+                [Constants.AfflictionTypes.ExhaustedWells] = 0, // Chests no longer grant [SacredWater|Sacred Water]
+                [Constants.AfflictionTypes.GateToll] = -100, // Lose 30 [SacredWater|Sacred Water] on room completion
+                [Constants.AfflictionTypes.LeakingWaterskin] = -100, // Lose 20 [SacredWater|Sacred Water] when you take Damage from an Enemy [HitDamage|Hit]
+                [Constants.AfflictionTypes.LowRivers] = -100, // 50% less [SacredWater|Sacred Water] found
                 // Free
-                ["Sharpened Arrowhead"] = 0, // You have no [Armour]
-                ["Rusted Mallet"] = 0, // Monsters always [Knockback]
-                ["Chains of Binding"] = 0, // Monsters inflict [BindingChains|Binding Chains] on [HitDamage|Hit]
-                ["Dishonoured Tattoo"] = 0, // 100% increased Damage Taken while on [LowLife|Low Life]
-                ["Tattered Blindfold"] = 0, // 90% reduced Light Radius
-                ["Dark Pit"] = 0, // Traps deal 100% increased Damage
-                ["Honed Claws"] = 0, // Monsters deal 30% more Damage
+                [Constants.AfflictionTypes.SharpenedArrowhead] = 0, // You have no [Armour]
+                [Constants.AfflictionTypes.RustedMallet] = 0, // Monsters always [Knockback]
+                [Constants.AfflictionTypes.ChainsOfBinding] = 0, // Monsters inflict [BindingChains|Binding Chains] on [HitDamage|Hit]
+                [Constants.AfflictionTypes.DishonouredTattoo] = 0, // 100% increased Damage Taken while on [LowLife|Low Life]
+                [Constants.AfflictionTypes.TatteredBlindfold] = 0, // 90% reduced Light Radius
+                [Constants.AfflictionTypes.DarkPit] = 0, // Traps deal 100% increased Damage
+                [Constants.AfflictionTypes.HonedClaws] = 0, // Monsters deal 30% more Damage
                 // Free Non-Melee
             },
-            RewardWeights = new()
+            RewardWeights = new() 
             {
-                ["Gold Key"] = 0,
-                ["Silver Key"] = 0,
-                ["Bronze Key"] = 0,
-                ["Golden Cache"] = 0,
-                ["Silver Cache"] = 0,
-                ["Bronze Cache"] = 0,
-                ["Large Fountain"] = 100,
-                ["Fountain"] = 50,
-                ["Pledge to Kochai"] = 20,
-                ["Honour Halani"] = 8,
-                ["Honour Ahkeli"] = -1,
-                ["Honour Orbala"] = 50,
-                ["Honour Galai"] = 300, // Restore Honour, Random Boon Cleanse Affliction
-                ["Honour Tabana"] = 0,
-                ["Merchant"] = 20 // Not important if sacred water is below ~360 (less with relics)
+                [Constants.RewardTypes.GoldKey] = 0,
+                [Constants.RewardTypes.SilverKey] = 0,
+                [Constants.RewardTypes.BronzeKey] = 0,
+                [Constants.RewardTypes.GoldenCache] = 0,
+                [Constants.RewardTypes.SilverCache] = 0,
+                [Constants.RewardTypes.BronzeCache] = 0,
+                [Constants.RewardTypes.LargeFountain] = 100,
+                [Constants.RewardTypes.Fountain] = 50,
+                [Constants.RewardTypes.PledgeToKochai] = 20,
+                [Constants.RewardTypes.HonourHalani] = 8,
+                [Constants.RewardTypes.HonourAhkeli] = -1,
+                [Constants.RewardTypes.HonourOrbala] = 50,
+                [Constants.RewardTypes.HonourGalai] = 300, // Restore Honour, Random Boon Cleanse Affliction
+                [Constants.RewardTypes.HonourTabana] = 0,
+                [Constants.RewardTypes.Merchant] = 20 // Not important if sacred water is below ~360 (less with relics)
             }
         };
     }
@@ -120,7 +121,6 @@ public class ProfileContent
     public static ProfileContent CreateDefaultProfile()
     {
         var profile = CreateBaseProfile();
-
         return profile;
     }
 
@@ -128,40 +128,82 @@ public class ProfileContent
     {
         var profile = CreateBaseProfile();
 
-        profile.RoomTypeWeights["Gauntlet"] = -200; // Predictable traps
-        profile.RoomTypeWeights["Hourglass"] = -1000; // Dangerous mob density
+        profile.RoomTypeWeights[Constants.RoomTypes.Gauntlet] = -200; // Predictable traps
+        profile.RoomTypeWeights[Constants.RoomTypes.Hourglass] = -1000; // Dangerous mob density
 
-        profile.AfflictionWeights["Death Toll"] = -500000; // Run-Ending
-        profile.AfflictionWeights["Spiked Exit"] = -600000; // Run-Ending
-        profile.AfflictionWeights["Deceptive Mirror"] = -400000; // Run-Ending
+        profile.AfflictionWeights[Constants.AfflictionTypes.DeathToll] = -500000; // Run-Ending
+        profile.AfflictionWeights[Constants.AfflictionTypes.SpikedExit] = -600000; // Run-Ending
+        profile.AfflictionWeights[Constants.AfflictionTypes.DeceptiveMirror] = -400000; // Run-Ending
 
-        profile.AfflictionWeights["Glass Shard"] = -50000; // ~3/58 chance of ending your run
-        profile.AfflictionWeights["Myriad Aspersions"] = -50000; // ~3/58 chance of ending your run every time you mess up
+        profile.AfflictionWeights[Constants.AfflictionTypes.GlassShard] = -50000; // ~3/58 chance of ending your run
+        profile.AfflictionWeights[Constants.AfflictionTypes.MyriadAspersions] = -50000; // ~3/58 chance of ending your run every time you mess up
 
         // Free
-        profile.AfflictionWeights["Ghastly Scythe"] = 0;
-        profile.AfflictionWeights["Deadly Snare"] = 0;
-        profile.AfflictionWeights["Branded Balbalakh"] = 0;
-        profile.AfflictionWeights["Chiselled Stone"] = 0;
-        profile.AfflictionWeights["Weakened Flesh"] = 0;
-        profile.AfflictionWeights["Costly Aid"] = 0;
-        profile.AfflictionWeights["Suspected Sympathiser"] = 0;
-        profile.AfflictionWeights["Haemorrhage"] = 0;
-        profile.AfflictionWeights["Leaking Waterskin"] = 0;
-        profile.AfflictionWeights["Rusted Mallet"] = 0;
-        profile.AfflictionWeights["Chains of Binding"] = 0;
-        profile.AfflictionWeights["Dishonoured Tattoo"] = 0;
-        profile.AfflictionWeights["Dark Pit"] = 0;
-        profile.AfflictionWeights["Honed Claws"] = 0;
-        profile.AfflictionWeights["Hungry Fangs"] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.GhastlyScythe] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.DeadlySnare] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.BrandedBalbalakh] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.ChiselledStone] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.WeakenedFlesh] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.CostlyAid] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.SuspectedSympathiser] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.Haemorrhage] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.LeakingWaterskin] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.RustedMallet] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.ChainsOfBinding] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.DishonouredTattoo] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.DarkPit] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.HonedClaws] = 0;
+        profile.AfflictionWeights[Constants.AfflictionTypes.HungryFangs] = 0;
 
         // Depends if the relic strategy works
-        // ["Forgotten Traditions"] = -1000, // 50% reduced Effect of your Non-[ItemRarity|Unique] [Relic|Relics]
-        // ["Orb of Negation"] = -1000, // Non-[ItemRarity|Unique] [Relic|Relics] have no Effect
+        // [WeightKeys.ForgottenTraditions] = -1000, // 50% reduced Effect of your Non-[ItemRarity|Unique] [Relic|Relics]
+        // [WeightKeys.ofNegation] = -1000, // Non-[ItemRarity|Unique] [Relic|Relics] have no Effect
 
         // Depends if you can't get your combo off in tim
-        // ["Fiendish Wings"] = -600, // Monsters' Action Speed cannot be slowed below base ||| Matters more if you're freezing/electrocuting the target
+        // [WeightKeys.FiendishWings] = -600, // Monsters' Action Speed cannot be slowed below base ||| Matters more if you're freezing/electrocuting the target
         return profile;
+    }
+
+    public static ProfileContent CreateNewProfileFromSettings(PathfindSanctumSettings settings) {
+        var profile = CreateBaseProfile();
+
+        MapWeightsToProfile(
+            profile.RoomTypeWeights, 
+            settings.CustomWeights.RoomTypeWeights,
+            (weights, key) => {
+                bool result = weights.GetWeight(key, out int value);
+                return (result, value);
+            },
+            (key, value) => profile.RoomTypeWeights[key] = value
+        );
+        
+        MapWeightsToProfile(
+            profile.AfflictionWeights,
+            settings.CustomWeights.AfflictionWeights,
+            (weights, key) => {
+                bool result = weights.GetWeight(key, out int value);
+                return (result, value);
+            },
+            (key, value) => profile.AfflictionWeights[key] = value    
+        );
+
+        MapWeightsToProfile(
+            profile.RewardWeights,
+            settings.CustomWeights.RewardWeights,
+            (weights, key) => {
+                bool result = weights.GetWeight(key, out int value);
+                return (result, value);
+            },
+            (key, value) => profile.RewardWeights[key] = value
+        );
+
+        return profile;
+    }
+
+    public void LoadProfile(PathfindSanctumSettings settings) {
+        MapWeightsToSettings(settings.CustomWeights.RoomTypeWeights, RoomTypeWeights, (weights, key, value) => weights.SetWeight(key, value));
+        MapWeightsToSettings(settings.CustomWeights.AfflictionWeights, AfflictionWeights, (weights, key, value) => weights.SetWeight(key, value));
+        MapWeightsToSettings(settings.CustomWeights.RewardWeights, RewardWeights, (weights, key, value) => weights.SetWeight(key, value));
     }
 
     public ProfileContent Clone()

--- a/ProfileManager.cs
+++ b/ProfileManager.cs
@@ -1,0 +1,66 @@
+﻿using ExileCore2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Xml.Linq;
+
+namespace PathfindSanctum {
+    internal class ProfileManager {
+        private PathfindSanctumSettings Settings { get; set; }
+        
+        internal string[] ProfileNames { 
+            get { return [.. Settings.Profiles.Keys]; } 
+        }
+
+        internal List<string> ProtectedProfiles { get; private set; } = new List<string> { Constants.Profiles.Default, Constants.Profiles.NoHit};
+
+        internal ProfileManager(PathfindSanctumSettings settings) {
+            Settings = settings;
+        }
+
+        internal void LoadSelectedProfile() {
+            Settings.Profiles[ProfileNames[Settings.selectedProfileIndex]].LoadProfile(Settings);
+        }
+
+        internal void SaveProfileAs(string name) {
+            var profiles = Settings.Profiles;
+            if (ProtectedProfiles.Contains(name) || string.IsNullOrWhiteSpace(name)) {
+                Logger.Log.Warning($"Saving profile failed! '{name}' is not a valid profile name.");
+                return;
+            }
+            if (Settings.Profiles.ContainsKey(name)) {
+                profiles[name] = ProfileContent.CreateNewProfileFromSettings(Settings);
+            } else {
+                profiles.Add(name, ProfileContent.CreateNewProfileFromSettings(Settings));
+                Settings.selectedProfileIndex = profiles.Count - 1;
+            }
+            LoadSelectedProfile();
+        }
+
+        internal void ResetCurrentProfileToDefault() {
+            var currentProfileName = Settings.CurrentProfile;
+            Settings.Profiles[currentProfileName] = currentProfileName switch {
+                Constants.Profiles.Default => ProfileContent.CreateDefaultProfile(),
+                Constants.Profiles.NoHit => ProfileContent.CreateNoHitProfile(),
+                _ => ProfileContent.CreateDefaultProfile()
+            };
+            LoadSelectedProfile();
+        }
+
+        internal void DeleteCurrentProfile() {
+            var currentProfile = Settings.CurrentProfile;
+            if (ProtectedProfiles.Contains(currentProfile)) {
+                Logger.Log.Warning($"Deleting profile failed! '{currentProfile}' is protected and can not be deleted.");
+                return;
+            }
+            Settings.Profiles.Remove(currentProfile);
+            if (Settings.selectedProfileIndex >= ProfileNames.Length) {
+                Settings.selectedProfileIndex = ProfileNames.Length - 1;
+            }
+            LoadSelectedProfile();
+        }
+    }
+}

--- a/WeightCalculator.cs
+++ b/WeightCalculator.cs
@@ -33,7 +33,7 @@ public class WeightCalculator(GameController gameController, PathfindSanctumSett
         if (roomType == null)
             return 0;
 
-        if (settings.GetWeightValue(roomType, out float typeWeight))
+        if (settings.Weights.RoomTypeWeights.GetWeight(roomType, out int typeWeight))
         {
             debugText.AppendLine($"{roomType}:{typeWeight}");
             return typeWeight;
@@ -57,7 +57,7 @@ public class WeightCalculator(GameController gameController, PathfindSanctumSett
                 debugText.AppendLine($"{afflictionName}:{dynamicWeight}");
             return (double)dynamicWeight;
         }
-        else if (settings.GetWeightValue(afflictionName, out float afflictionWeight))
+        else if (settings.Weights.AfflictionWeights.GetWeight(afflictionName, out int afflictionWeight))
         {
             if (settings.DebugSettings.DebugEnable.Value)
                 debugText.AppendLine($"{afflictionName}:{afflictionWeight}");
@@ -139,7 +139,7 @@ public class WeightCalculator(GameController gameController, PathfindSanctumSett
     {
         if (
             room?.Reward != null
-            && settings.GetWeightValue(room.Reward, out float rewardWeight)
+            && settings.Weights.RewardWeights.GetWeight(room.Reward, out int rewardWeight)
         )
         {
             if (settings.DebugSettings.DebugEnable.Value)

--- a/WeightSettings.cs
+++ b/WeightSettings.cs
@@ -1,0 +1,46 @@
+﻿using ExileCore2;
+using ExileCore2.Shared.Attributes;
+using ExileCore2.Shared.Nodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PathfindSanctum {
+    public abstract class WeightSettings {
+
+        private readonly Dictionary<string, PropertyInfo> _propertyCache;
+
+        protected WeightSettings() {
+            _propertyCache = GetType().GetProperties()
+                .Where(p => p.GetCustomAttributes(typeof(MenuAttribute), true).Any())
+                .ToDictionary(p => ((MenuAttribute)p.GetCustomAttributes(typeof(MenuAttribute), true).First()).MenuName);
+        }
+
+        internal bool GetWeight(string key, out int value) {
+            if (_propertyCache.TryGetValue(key, out var property)) {
+                var rangeNode = property.GetValue(this, null) as RangeNode<int>;
+                if (rangeNode != null) {
+                    value = rangeNode.Value;
+                    return true;
+                }
+            }
+            Logger.Log.Error($"Error getting weight value! Weight with key '{key}' could not be found in settings type '{GetType().Name}'");
+            value = 0;
+            return false;
+        }
+
+        internal void SetWeight(string key, float value) {
+            if (_propertyCache.TryGetValue(key, out var property)) {
+                var rangeNode = property.GetValue(this, null) as RangeNode<int>;
+                if (rangeNode != null) {
+                    rangeNode.Value = (int)value;
+                    return;
+                }
+            }
+            Logger.Log.Error($"Error while setting weight value! Weight with key '{key}' could not be found in settings type '{GetType().Name}'");
+        }
+    }
+}


### PR DESCRIPTION
Hey there, sorry for the commits being wacky. Had this lying around locally and doing them after the fact always sucks..
So here's a rundown:
* All weights (rooms, afflictions, rewards) have a slider added in settings
  * Changes are reflected in the overlay in real-time
* Added profile management to settings menu
  * Switch between profiles on the fly
    * Loads profile weights into settings menu
  * Save currently configured weights as new profile or to currently selected profile (excluding built in profiles)
  * Reset current profile to default
  * Delete profile (excluding built in)
* Dynamic weights calculation for afflictions removing defenses added as configurable settings in its own section
* Added setting to change debug text font size
* Reorganized settings into sections

Internally:
* Switched to constants for all the key strings, allowing to reliably map settings to profile weights and vice-versa via helper functions using reflection which saves a lot of 'dumb code' (reflection stuff is cached and doesn't run on render anyways; it's just for saving/loading profiles)
* Profile Selection, buttons and dialogs are rendered via DrawSettings() override

That's about it, I think.